### PR TITLE
Upgrade to Minecraft 26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ on:
       - "src/**"
       - "gradle.properties"
       - "build.gradle"
-      - "MultiVersion"
-      - ".gitmodules"
+      - "gradle/**"
       - ".github/workflows/build.yml"
     tags-ignore: [ "**" ]
 
@@ -23,18 +22,12 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          submodules: true
 
       - name: Setup Java
         uses: actions/setup-java@v4.0.0
         with:
           distribution: "temurin"
-          java-version: 21
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.12.0"
+          java-version: 25
 
       - name: Mark executable
         run: chmod +x ./gradlew

--- a/.github/workflows/modrinth.yml
+++ b/.github/workflows/modrinth.yml
@@ -12,14 +12,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.1.1
-        with:
-          submodules: true
 
       - name: Setup Java
         uses: actions/setup-java@v4.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
 
       - name: Mark Executable
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version "${loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 }
 
 version = project.mod_version
@@ -9,43 +9,40 @@ base {
 	archivesName = project.archives_base_name
 }
 
-dependencies {
-	// To change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+repositories {
+}
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	
+dependencies {
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 }
 
 processResources {
-	inputs.property "version", project.version
+	def version = project.version
+	inputs.property "version", version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": inputs.properties.version
+		expand "version": version
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
-	//noinspection GroovyAssignabilityCheck, GroovyAccessibility
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
-	inputs.property "archivesName", project.base.archivesName
+	def archivesName = project.base.archivesName.get()
+	inputs.property "archivesName", archivesName
 
 	from("LICENSE") {
-		rename { "${it}_${inputs.properties.archivesName}"}
+		rename { "${it}_${archivesName}"}
 	}
 }
-
-
-
-apply from: './MultiVersion/multi-version.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.configuration-cache=false
 org.gradle.caching=true
 
 # Mod Properties
-mod_version=1.0.2
+mod_version=1.1.0
 maven_group=dev.gxlg.autoenchanter
 archives_base_name=auto-enchanter
 
 # Fabric Properties
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.4
-loom_version=1.14-SNAPSHOT
+# check these on https://fabricmc.net/develop
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
-# Fabric API
-fabric_version=0.140.2+1.21.11
+# Dependencies
+fabric_api_version=0.154.2+26.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/multi-version.json
+++ b/multi-version.json
@@ -1,4 +1,0 @@
-{
-  "root": "main/java/dev/gxlg/autoenchanter",
-  "package": "dev.gxlg.autoenchanter"
-}

--- a/src/main/java/dev/gxlg/autoenchanter/AutoEnchanter.java
+++ b/src/main/java/dev/gxlg/autoenchanter/AutoEnchanter.java
@@ -1,9 +1,8 @@
 package dev.gxlg.autoenchanter;
 
 import net.fabricmc.api.ClientModInitializer;
-
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,9 +14,9 @@ public class AutoEnchanter implements ClientModInitializer {
 	public void onInitializeClient() {
 		LOGGER.info("Hello from Auto Enchanter!");
 
-		ClientCommandRegistrationCallback.EVENT.register((l, d) -> l
-				.register(ClientCommandManager.literal("autoenchanter")
-						.then(ClientCommandManager.literal("cancel").executes(Worker::cancelCommand))
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> dispatcher
+				.register(ClientCommands.literal("autoenchanter")
+						.then(ClientCommands.literal("cancel").executes(Worker::cancelCommand))
 				)
 		);
 	}

--- a/src/main/java/dev/gxlg/autoenchanter/DataStructures.java
+++ b/src/main/java/dev/gxlg/autoenchanter/DataStructures.java
@@ -1,18 +1,18 @@
 package dev.gxlg.autoenchanter;
 
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.component.type.ItemEnchantmentsComponent;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.registry.entry.RegistryEntry;
-
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 
 public class DataStructures {
     public record IterItem<S>(long index, long total, S current) {
@@ -52,12 +52,12 @@ public class DataStructures {
             return new FilledShape(left.fillInternal(list), right.fillInternal(list));
         }
 
-        public Stream<List<Enchant>> possibleFills(List<Enchant> alreadyFilled, Map<Integer, List<Enchant>> map, RegistryEntry<Enchantment> current, Enchant main) {
+        public Stream<List<Enchant>> possibleFills(List<Enchant> alreadyFilled, Map<Integer, List<Enchant>> map, Holder<Enchantment> current, Enchant main) {
             List<Enchant> allItems = map.values().stream().flatMap(List::stream).toList();
             return possibleFillsInternal(alreadyFilled, MergeTree.from(map), 0, allItems, current, main);
         }
 
-        private Stream<List<Enchant>> possibleFillsInternal(List<Enchant> alreadyFilled, MergeTree tree, int indexOffset, List<Enchant> items, RegistryEntry<Enchantment> currentEnchantment, Enchant main) {
+        private Stream<List<Enchant>> possibleFillsInternal(List<Enchant> alreadyFilled, MergeTree tree, int indexOffset, List<Enchant> items, Holder<Enchantment> currentEnchantment, Enchant main) {
             if (tree.value() == 0) {
                 return Stream.of(alreadyFilled.subList(indexOffset, indexOffset + leafs()));
             }
@@ -89,19 +89,19 @@ public class DataStructures {
             return splits.stream().flatMap(split -> left.possibleFillsInternal(alreadyFilled, split.getKey(), indexOffset, items, currentEnchantment, main).flatMap(ll -> right.possibleFillsInternal(alreadyFilled, split.getValue(), indexOffset + left.leafs(), items.stream().filter(i -> ll.stream().noneMatch(j -> i == j)).toList(), currentEnchantment, main).map(rr -> Stream.concat(ll.stream(), rr.stream()).toList())));
         }
 
-        public void draw(DrawContext context, TextRenderer textRenderer, int x, int y, int w, int h) {
+        public void draw(GuiGraphicsExtractor context, Font textRenderer, int x, int y, int w, int h) {
             draw(context, textRenderer, x, y, w, h, 0, 0);
         }
 
         @SuppressWarnings("unused")
-        private void draw(DrawContext context, TextRenderer textRenderer, int x, int y, int w, int h, int depth, int cost) {
+        private void draw(GuiGraphicsExtractor context, Font textRenderer, int x, int y, int w, int h, int depth, int cost) {
             int color = 0xF2DCA0 + (0x6D12A6 - 0xF2DCA0) * depth / 6;
             int base = 0xFF000000;
             context.fill(x, y, x + w, y + h, base + color / 2);
             context.fill(x + 1, y + 1, x + w - 1, y + h - 1, base + color);
 
             if (isLeaf()) {
-                Object ignored = Reflection.wrap("@context method_51433/drawText @textRenderer @String.valueOf(cost) int:x+3 int:y+3 int:0xFF000000 boolean:false");
+                context.text(textRenderer, String.valueOf(cost), x + 3, y + 3, 0xFF000000, false);
                 return;
             }
 
@@ -149,34 +149,21 @@ public class DataStructures {
         }
     }
 
-    @SuppressWarnings({"unused", "DataFlowIssue"})
-    public record Enchant(Map<RegistryEntry<Enchantment>, EMap> enchantments, int anvilUse, Item item) {
+    public record Enchant(Map<Holder<Enchantment>, EMap> enchantments, int anvilUse, Item item) {
         public static Enchant from(ItemStack stack) {
-            Integer r;
-            Object rc = Reflection.wrap("[net.minecraft.class_9334/net.minecraft.component.DataComponentTypes]:null field_49639/REPAIR_COST");
-            if (Reflection.version(">= 1.21.5")) {
-                r = (Integer) Reflection.wrap("[net.minecraft.class_9323/net.minecraft.component.ComponentMap]:stack.getComponents() method_58694/get [net.minecraft.class_9331/net.minecraft.component.ComponentType]:rc");
-            } else if (Reflection.version(">= 1.21")) {
-                r = (Integer) Reflection.wrap("[net.minecraft.class_9323/net.minecraft.component.ComponentMap]:stack.getComponents() method_57829/get [net.minecraft.class_9331/net.minecraft.component.ComponentType]:rc");
-            } else {
-                r = (Integer) Reflection.wrap("[net.minecraft.class_9323/net.minecraft.component.ComponentMap]:stack.getComponents() method_57829/get [net.minecraft.class_9331/net.minecraft.component.DataComponentType]:rc");
-            }
-            int repair = Optional.ofNullable(r).orElse(0);
+            int repair = stack.getOrDefault(DataComponents.REPAIR_COST, 0);
             int anvilUse = Integer.bitCount(repair);
 
-            ItemEnchantmentsComponent component = EnchantmentHelper.getEnchantments(stack);
-            Map<RegistryEntry<Enchantment>, EMap> enchantments = component.getEnchantments().stream().collect(Collectors.toMap(i -> i, i -> {
-                int lvl = (Integer) (Reflection.version(">= 1.21") ?
-                        Reflection.wrap("@component method_57536/getLevel RegistryEntry:i") :
-                        Reflection.wrap("@component method_57536/getLevel Enchantment:i.value()"));
-                return EMap.from(lvl, i.value().getAnvilCost());
-            }));
+            ItemEnchantments component = EnchantmentHelper.getEnchantmentsForCrafting(stack);
+            Map<Holder<Enchantment>, EMap> enchantments = component.keySet().stream().collect(Collectors.toMap(
+                    holder -> holder,
+                    holder -> EMap.from(component.getLevel(holder), holder.value().getAnvilCost())
+            ));
             return new Enchant(enchantments, anvilUse, stack.getItem());
         }
-
     }
 
-    public record EnchantedItem(Map<RegistryEntry<Enchantment>, EMap> enchantments, int anvilUse, int cost, Item item) {
+    public record EnchantedItem(Map<Holder<Enchantment>, EMap> enchantments, int anvilUse, int cost, Item item) {
         public static EnchantedItem INVALID = new EnchantedItem(Collections.emptyMap(), -1, -1, null);
 
         public boolean matches(ItemStack stack) {
@@ -248,16 +235,16 @@ public class DataStructures {
             if (l.item() == Items.ENCHANTED_BOOK && r.item() != Items.ENCHANTED_BOOK)
                 return EnchantedItem.INVALID; // can't use an item as a sacrifice if the target is a book
 
-            Map<RegistryEntry<Enchantment>, EMap> enchantments = new HashMap<>();
+            Map<Holder<Enchantment>, EMap> enchantments = new HashMap<>();
             int c = 0;
             boolean anyValid = false;
-            for (Map.Entry<RegistryEntry<Enchantment>, EMap> e : r.enchantments().entrySet()) {
-                RegistryEntry<Enchantment> sacrifice = e.getKey();
+            for (Map.Entry<Holder<Enchantment>, EMap> e : r.enchantments().entrySet()) {
+                Holder<Enchantment> sacrifice = e.getKey();
                 EMap sacrificeData = e.getValue();
 
                 boolean pair = false;
-                for (Map.Entry<RegistryEntry<Enchantment>, EMap> d : l.enchantments().entrySet()) {
-                    RegistryEntry<Enchantment> target = d.getKey();
+                for (Map.Entry<Holder<Enchantment>, EMap> d : l.enchantments().entrySet()) {
+                    Holder<Enchantment> target = d.getKey();
                     EMap targetData = d.getValue();
 
                     if (target == sacrifice) {
@@ -283,7 +270,7 @@ public class DataStructures {
                         c += 1;
                     }
                 }
-                if (!pair && (sacrifice.value().isAcceptableItem(l.item().getDefaultStack()) || l.item() == Items.ENCHANTED_BOOK)) {
+                if (!pair && (sacrifice.value().canEnchant(l.item().getDefaultInstance()) || l.item() == Items.ENCHANTED_BOOK)) {
                     anyValid = true;
                     enchantments.put(sacrifice, sacrificeData);
                     c += sacrificeData.cost(r.item()) * sacrificeData.lvl();
@@ -291,7 +278,7 @@ public class DataStructures {
             }
             if (!anyValid) return EnchantedItem.INVALID; // no enchantments were applied
 
-            for (Map.Entry<RegistryEntry<Enchantment>, EMap> d : l.enchantments().entrySet()) {
+            for (Map.Entry<Holder<Enchantment>, EMap> d : l.enchantments().entrySet()) {
                 if (!enchantments.containsKey(d.getKey())) enchantments.put(d.getKey(), d.getValue());
             }
 

--- a/src/main/java/dev/gxlg/autoenchanter/MultiVersion.java
+++ b/src/main/java/dev/gxlg/autoenchanter/MultiVersion.java
@@ -1,29 +1,17 @@
 package dev.gxlg.autoenchanter;
 
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.enchantment.Enchantment;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-@SuppressWarnings("unused")
 public class MultiVersion {
-    private static final Map<Set<RegistryEntry<Enchantment>>, Boolean> cacheCombine = new HashMap<>();
+	private static final Map<Set<Holder<Enchantment>>, Boolean> cacheCombine = new HashMap<>();
 
-    public static boolean canCombine(RegistryEntry<Enchantment> a, RegistryEntry<Enchantment> b) {
-        Set<RegistryEntry<Enchantment>> pair = Set.of(a, b);
-        if (cacheCombine.containsKey(pair)) return cacheCombine.get(pair);
-
-        Class<?> re = RegistryEntry.class;
-        boolean res;
-        if (Reflection.version(">= 1.21")) {
-            res = (Boolean) Reflection.wrap("[net.minecraft.class_1887/net.minecraft.enchantment.Enchantment]:null method_60033/canBeCombined re:a re:b");
-        } else {
-            Class<?> e = Enchantment.class;
-            res = (Boolean) Reflection.wrap("e:a.value() method_8188/canCombine e:b.value()");
-        }
-        cacheCombine.put(pair, res);
-        return res;
-    }
+	public static boolean canCombine(Holder<Enchantment> a, Holder<Enchantment> b) {
+		Set<Holder<Enchantment>> pair = Set.of(a, b);
+		return cacheCombine.computeIfAbsent(pair, ignored -> Enchantment.areCompatible(a, b));
+	}
 }

--- a/src/main/java/dev/gxlg/autoenchanter/Reflection.java
+++ b/src/main/java/dev/gxlg/autoenchanter/Reflection.java
@@ -1,7 +1,0 @@
-package dev.gxlg.autoenchanter;
-
-@SuppressWarnings("unused")
-public class Reflection {
-    public static Object wrap(String i) { return new Object(); }
-    public static boolean version(String i) { return true; }
-}

--- a/src/main/java/dev/gxlg/autoenchanter/Utils.java
+++ b/src/main/java/dev/gxlg/autoenchanter/Utils.java
@@ -1,8 +1,5 @@
 package dev.gxlg.autoenchanter;
 
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.registry.entry.RegistryEntry;
-
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.*;
@@ -11,8 +8,17 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.enchantment.Enchantment;
 
 import static dev.gxlg.autoenchanter.DataStructures.*;
+
+import dev.gxlg.autoenchanter.DataStructures.Enchant;
+import dev.gxlg.autoenchanter.DataStructures.EnchantedItem;
+import dev.gxlg.autoenchanter.DataStructures.FilledShape;
+import dev.gxlg.autoenchanter.DataStructures.IterItem;
+import dev.gxlg.autoenchanter.DataStructures.Leaf;
+import dev.gxlg.autoenchanter.DataStructures.Shape;
 
 public class Utils {
     private static BigInteger countWithDepth(int amount, int depth, int maxDepth, Map<Long, BigInteger> memo) {
@@ -60,10 +66,10 @@ public class Utils {
         });
     }
 
-    private static Stream<List<Enchant>> fills(Shape tree, List<Enchant> filled, Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> map, Enchant main, Set<RegistryEntry<Enchantment>> ignoredEncs) {
+    private static Stream<List<Enchant>> fills(Shape tree, List<Enchant> filled, Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> map, Enchant main, Set<Holder<Enchantment>> ignoredEncs) {
         if (map.size() == 0) return Stream.of(filled);
-        Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> m = new HashMap<>(map);
-        RegistryEntry<Enchantment> first;
+        Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> m = new HashMap<>(map);
+        Holder<Enchantment> first;
         do {
             first = m.keySet().stream().findFirst().orElseThrow();
             m.remove(first);
@@ -76,17 +82,17 @@ public class Utils {
         private final AtomicReference<Map.Entry<FilledShape, Integer>> bestShape = new AtomicReference<>();
         private final int amount;
         private final Enchant mainItem;
-        private final Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> trueMap;
+        private final Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> trueMap;
         private final List<Enchant> collection;
         private final ExecutorService pool;
         private final int threads;
         private final BlockingQueue<IterItem<Shape>> queue;
-        private final Set<RegistryEntry<Enchantment>> ignoredEncs;
-        private final Map<RegistryEntry<Enchantment>, Integer> maxMap;
+        private final Set<Holder<Enchantment>> ignoredEncs;
+        private final Map<Holder<Enchantment>, Integer> maxMap;
         private volatile boolean submitting = true;
         private final AtomicInteger finished = new AtomicInteger(0);
 
-        public ShapePool(int amount, List<Enchant> collection, Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> trueMap, Enchant mainItem, Set<RegistryEntry<Enchantment>> ignoredEncs, Map<RegistryEntry<Enchantment>, Integer> maxMap) {
+        public ShapePool(int amount, List<Enchant> collection, Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> trueMap, Enchant mainItem, Set<Holder<Enchantment>> ignoredEncs, Map<Holder<Enchantment>, Integer> maxMap) {
             this.amount = amount;
             this.collection = collection;
             this.trueMap = trueMap;

--- a/src/main/java/dev/gxlg/autoenchanter/Worker.java
+++ b/src/main/java/dev/gxlg/autoenchanter/Worker.java
@@ -1,23 +1,29 @@
 package dev.gxlg.autoenchanter;
 
 import com.mojang.brigadier.context.CommandContext;
+import dev.gxlg.autoenchanter.DataStructures.AnvilItem;
+import dev.gxlg.autoenchanter.DataStructures.EMap;
+import dev.gxlg.autoenchanter.DataStructures.Enchant;
+import dev.gxlg.autoenchanter.DataStructures.EnchantedItem;
+import dev.gxlg.autoenchanter.DataStructures.FilledShape;
+import dev.gxlg.autoenchanter.DataStructures.IterItem;
+import dev.gxlg.autoenchanter.DataStructures.Shape;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ingame.AnvilScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.screen.ScreenHandler;
-import net.minecraft.screen.slot.SlotActionType;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.screens.inventory.AnvilScreen;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.Holder;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
 import java.util.*;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -26,8 +32,8 @@ import static dev.gxlg.autoenchanter.DataStructures.*;
 
 public class Worker {
 
-    private static TextWidget textDisplay;
-    private static ButtonWidget buttonSelect, buttonCalculate, buttonCancel, buttonStart;
+    private static StringWidget textDisplay;
+    private static Button buttonSelect, buttonCalculate, buttonCancel, buttonStart;
     private static State state = State.UNSET;
 
 
@@ -39,7 +45,7 @@ public class Worker {
     private static IterItem<Shape> current = null;
     private static List<AnvilItem> operations = null;
 
-    public static void setup(TextWidget text, ButtonWidget select, ButtonWidget calculate, ButtonWidget start, ButtonWidget cancel) {
+    public static void setup(StringWidget text, Button select, Button calculate, Button start, Button cancel) {
         textDisplay = text;
         buttonSelect = select;
         buttonCalculate = calculate;
@@ -80,7 +86,7 @@ public class Worker {
 
     public static int cancelCommand(CommandContext<FabricClientCommandSource> context) {
         cancel();
-        context.getSource().sendFeedback(Text.of("Cancelled everything"));
+        context.getSource().sendFeedback(Component.nullToEmpty("Cancelled everything"));
         return 0;
     }
 
@@ -107,18 +113,18 @@ public class Worker {
             return;
         }
 
-        MinecraftClient client = MinecraftClient.getInstance();
-        ClientPlayerEntity player = client.player;
+        Minecraft client = Minecraft.getInstance();
+        LocalPlayer player = client.player;
         if (player == null) return;
 
-        ScreenHandler handler = player.currentScreenHandler;
+        AbstractContainerMenu handler = player.containerMenu;
         if (handler == null) return;
 
         List<Enchant> collection = new ArrayList<>();
         Enchant mainItem = null;
 
         for (int slot : selected) {
-            ItemStack stack = handler.getSlot(slot).getStack();
+            ItemStack stack = handler.getSlot(slot).getItem();
             Enchant item = Enchant.from(stack);
             collection.add(item);
             if (mainItem == null) mainItem = item;
@@ -126,7 +132,7 @@ public class Worker {
 
         boolean conflicts = false;
 
-        Set<RegistryEntry<Enchantment>> ignoredEncs = new HashSet<>();
+        Set<Holder<Enchantment>> ignoredEncs = new HashSet<>();
         for (int i = 0; i < collection.size() - 1; i++) {
             Enchant b = collection.get(i);
             if (b.enchantments().size() == 0) continue;
@@ -134,9 +140,9 @@ public class Worker {
             boolean anyToItem = false;
             for (int j = i + 1; j < collection.size(); j++) {
                 Enchant c = collection.get(j);
-                for (RegistryEntry<Enchantment> d : b.enchantments().keySet()) {
+                for (Holder<Enchantment> d : b.enchantments().keySet()) {
                     boolean anyCompat = false;
-                    for (RegistryEntry<Enchantment> e : c.enchantments().keySet()) {
+                    for (Holder<Enchantment> e : c.enchantments().keySet()) {
                         if (d == e || MultiVersion.canCombine(d, e)) anyCompat = true;
                         if (d != e && !MultiVersion.canCombine(d, e)) {
                             if (b == mainItem) {
@@ -149,7 +155,7 @@ public class Worker {
                         break;
                     }
 
-                    if (d.value().isAcceptableItem(mainItem.item().getDefaultStack()) || mainItem.item() == Items.ENCHANTED_BOOK)
+                    if (d.value().canEnchant(mainItem.item().getDefaultInstance()) || mainItem.item() == Items.ENCHANTED_BOOK)
                         anyToItem = true;
                 }
             }
@@ -164,10 +170,10 @@ public class Worker {
             return;
         }
 
-        Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> map = new HashMap<>();
+        Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> map = new HashMap<>();
         for (Enchant item : collection) {
-            for (Map.Entry<RegistryEntry<Enchantment>, EMap> e : item.enchantments().entrySet()) {
-                RegistryEntry<Enchantment> enc = e.getKey();
+            for (Map.Entry<Holder<Enchantment>, EMap> e : item.enchantments().entrySet()) {
+                Holder<Enchantment> enc = e.getKey();
                 int lvl = e.getValue().lvl();
 
                 if (!map.containsKey(enc)) map.put(enc, new HashMap<>());
@@ -177,10 +183,10 @@ public class Worker {
             }
         }
 
-        Map<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> trueMap = new HashMap<>();
-        Map<RegistryEntry<Enchantment>, Integer> wasted = new HashMap<>();
-        Map<RegistryEntry<Enchantment>, Integer> maxMap = new HashMap<>();
-        for (Map.Entry<RegistryEntry<Enchantment>, Map<Integer, List<Enchant>>> e : map.entrySet()) {
+        Map<Holder<Enchantment>, Map<Integer, List<Enchant>>> trueMap = new HashMap<>();
+        Map<Holder<Enchantment>, Integer> wasted = new HashMap<>();
+        Map<Holder<Enchantment>, Integer> maxMap = new HashMap<>();
+        for (Map.Entry<Holder<Enchantment>, Map<Integer, List<Enchant>>> e : map.entrySet()) {
             List<Enchant> en = e.getValue().values().stream().findFirst().orElseThrow();
             if (e.getValue().size() == 1 && en.size() == 1) {
                 maxMap.put(e.getKey(), e.getValue().keySet().stream().toList().getFirst());
@@ -243,16 +249,16 @@ public class Worker {
     }
 
     public static void start() {
-        MinecraftClient client = MinecraftClient.getInstance();
-        ClientPlayerEntity player = client.player;
+        Minecraft client = Minecraft.getInstance();
+        LocalPlayer player = client.player;
         if (player == null) return;
-        ScreenHandler handler = player.currentScreenHandler;
+        AbstractContainerMenu handler = player.containerMenu;
 
         List<EnchantedItem> outputs = operations.subList(opid, operations.size()).stream().map(AnvilItem::result).toList();
         List<EnchantedItem> inputs = operations.subList(opid, operations.size()).stream().flatMap(e -> Stream.of(e.target(), e.sacrifice())).filter(i -> outputs.stream().noneMatch(j -> j == i)).toList();
         Set<Integer> found = new HashSet<>();
         for (EnchantedItem inp : inputs) {
-            int slot = IntStream.range(3, handler.getStacks().size()).boxed().filter(i -> !found.contains(i) && inp.matches(handler.getSlot(i).getStack())).findFirst().orElse(-1);
+            int slot = IntStream.range(3, handler.getItems().size()).boxed().filter(i -> !found.contains(i) && inp.matches(handler.getSlot(i).getItem())).findFirst().orElse(-1);
             if (slot == -1) {
                 showText("Not all items for enchanting are present", Colors.RED);
                 return;
@@ -276,11 +282,11 @@ public class Worker {
     public static void tick() {
         if (state == State.UNSET || state == State.SELECT) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
-        ClientPlayerInteractionManager manager = client.interactionManager;
-        ClientPlayerEntity player = client.player;
+        Minecraft client = Minecraft.getInstance();
+        MultiPlayerGameMode manager = client.gameMode;
+        LocalPlayer player = client.player;
         if (player == null || manager == null) return;
-        ScreenHandler handler = player.currentScreenHandler;
+        AbstractContainerMenu handler = player.containerMenu;
 
         if (state == State.CALCULATE) {
             if (search.working()) {
@@ -294,8 +300,8 @@ public class Worker {
             if (m == null) {
                 cancel();
                 showText("Couldn't find a tree", Colors.RED);
-                if (!(client.currentScreen instanceof AnvilScreen)) {
-                    player.sendMessage(Text.literal("Couldn't find a tree").formatted(Formatting.RED), false);
+                if (!(client.gui.screen() instanceof AnvilScreen)) {
+                    player.sendSystemMessage(Component.literal("Couldn't find a tree").withStyle(ChatFormatting.RED));
                 }
                 return;
             }
@@ -304,12 +310,12 @@ public class Worker {
             operations = m.execute();
 
             ready();
-            if (!(client.currentScreen instanceof AnvilScreen)) {
-                player.sendMessage(Text.literal("Can enchant for " + enchantCost + " lvls").formatted(Formatting.GREEN), false);
+            if (!(client.gui.screen() instanceof AnvilScreen)) {
+                player.sendSystemMessage(Component.literal("Can enchant for " + enchantCost + " lvls").withStyle(ChatFormatting.GREEN));
             }
 
         } else if (state == State.EXEC) {
-            if (!(client.currentScreen instanceof AnvilScreen)) {
+            if (!(client.gui.screen() instanceof AnvilScreen)) {
                 sopid = 0;
                 return;
             }
@@ -322,37 +328,37 @@ public class Worker {
 
             AnvilItem current = operations.get(opid);
             int cost = current.result().cost() - current.sacrifice().cost() - current.target().cost();
-            if (!player.isInCreativeMode() && player.experienceLevel < cost) {
+            if (!player.hasInfiniteMaterials() && player.experienceLevel < cost) {
                 showText("Not enough levels for the current combo, needed: " + cost, Colors.RED);
                 return;
             }
 
             if (sopid == 0) {
                 EnchantedItem item = current.target();
-                if (item.matches(handler.getSlot(0).getStack())) {
+                if (item.matches(handler.getSlot(0).getItem())) {
                     sopid = 1;
                     return;
                 }
-                int slot = IntStream.range(3, handler.getStacks().size()).boxed().filter(i -> item.matches(handler.getSlot(i).getStack())).findFirst().orElse(-1);
+                int slot = IntStream.range(3, handler.getItems().size()).boxed().filter(i -> item.matches(handler.getSlot(i).getItem())).findFirst().orElse(-1);
                 if (slot == -1) return;
-                manager.clickSlot(handler.syncId, slot, 0, SlotActionType.QUICK_MOVE, player);
+                manager.handleContainerInput(handler.containerId, slot, 0, ContainerInput.QUICK_MOVE, player);
 
             } else if (sopid == 1) {
                 EnchantedItem item = current.sacrifice();
-                if (item.matches(handler.getSlot(1).getStack())) {
+                if (item.matches(handler.getSlot(1).getItem())) {
                     sopid = 2;
                     return;
                 }
-                int slot = IntStream.range(3, handler.getStacks().size()).boxed().filter(i -> item.matches(handler.getSlot(i).getStack())).findFirst().orElse(-1);
+                int slot = IntStream.range(3, handler.getItems().size()).boxed().filter(i -> item.matches(handler.getSlot(i).getItem())).findFirst().orElse(-1);
                 if (slot == -1) return;
-                manager.clickSlot(handler.syncId, slot, 0, SlotActionType.QUICK_MOVE, player);
+                manager.handleContainerInput(handler.containerId, slot, 0, ContainerInput.QUICK_MOVE, player);
 
             } else if (sopid == 2) {
                 EnchantedItem item = current.result();
-                if (!item.matches(handler.getSlot(2).getStack())) {
+                if (!item.matches(handler.getSlot(2).getItem())) {
                     return;
                 }
-                manager.clickSlot(handler.syncId, 2, 0, SlotActionType.QUICK_MOVE, player);
+                manager.handleContainerInput(handler.containerId, 2, 0, ContainerInput.QUICK_MOVE, player);
 
                 timer = -10;
                 opid++;
@@ -371,7 +377,7 @@ public class Worker {
 
 
     private static void showText(String text, int color) {
-        textDisplay.setMessage(Text.literal(text).setStyle(Style.EMPTY.withColor(color)));
+        textDisplay.setMessage(Component.literal(text).setStyle(Style.EMPTY.withColor(color)));
         textDisplay.visible = true;
     }
 

--- a/src/main/java/dev/gxlg/autoenchanter/mixin/AnvilMixin.java
+++ b/src/main/java/dev/gxlg/autoenchanter/mixin/AnvilMixin.java
@@ -2,71 +2,66 @@ package dev.gxlg.autoenchanter.mixin;
 
 import dev.gxlg.autoenchanter.Colors;
 import dev.gxlg.autoenchanter.DataStructures;
-import dev.gxlg.autoenchanter.Reflection;
 import dev.gxlg.autoenchanter.Worker;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.ingame.AnvilScreen;
-import net.minecraft.client.gui.screen.ingame.ForgingScreen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.TextWidget;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.screen.AnvilScreenHandler;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.screens.inventory.AnvilScreen;
+import net.minecraft.client.gui.screens.inventory.ItemCombinerScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AnvilMenu;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@SuppressWarnings("UnresolvedMixinReference")
 @Mixin(AnvilScreen.class)
-public abstract class AnvilMixin extends ForgingScreen<AnvilScreenHandler> {
+public abstract class AnvilMixin extends ItemCombinerScreen<AnvilMenu> {
 
-    public AnvilMixin(AnvilScreenHandler handler, PlayerInventory playerInventory, Text title, Identifier texture) {
-        super(handler, playerInventory, title, texture);
-    }
+	public AnvilMixin(AnvilMenu menu, Inventory playerInventory, Component title, Identifier texture) {
+		super(menu, playerInventory, title, texture);
+	}
 
-    @Inject(at = @At("TAIL"), method = "setup")
-    private void setup(CallbackInfo ci) {
-        assert client != null;
-        TextWidget text = new TextWidget(20, 20, width - 40, 20, Text.empty(), textRenderer);
-        if (Reflection.version("<= 1.21.8")) {
-            Object ignored = Reflection.wrap("@text method_48596/alignLeft");
-        }
-        this.addDrawableChild(text);
+	@Inject(at = @At("TAIL"), method = "subInit")
+	private void setup(CallbackInfo ci) {
+		assert minecraft != null;
+		StringWidget text = new StringWidget(20, 20, width - 40, 20, Component.empty(), font);
+		this.addRenderableWidget(text);
 
-        ButtonWidget buttonSelect = new ButtonWidget.Builder(Text.of("Select items"), b -> Worker.select()).dimensions(20, 45, 100, 20).build();
-        ButtonWidget buttonCalculate = new ButtonWidget.Builder(Text.of("Calculate"), b -> Worker.calculate()).dimensions(20, 45, 100, 20).build();
-        ButtonWidget buttonStart = new ButtonWidget.Builder(Text.of("Start enchanting"), b -> Worker.start()).dimensions(20, 45, 100, 20).build();
-        ButtonWidget buttonCancel = new ButtonWidget.Builder(Text.of("Cancel"), b -> Worker.cancel()).dimensions(20, 67, 100, 20).build();
+		Button buttonSelect = Button.builder(Component.literal("Select items"), b -> Worker.select()).bounds(20, 45, 100, 20).build();
+		Button buttonCalculate = Button.builder(Component.literal("Calculate"), b -> Worker.calculate()).bounds(20, 45, 100, 20).build();
+		Button buttonStart = Button.builder(Component.literal("Start enchanting"), b -> Worker.start()).bounds(20, 45, 100, 20).build();
+		Button buttonCancel = Button.builder(Component.literal("Cancel"), b -> Worker.cancel()).bounds(20, 67, 100, 20).build();
 
-        this.addDrawableChild(buttonSelect);
-        this.addDrawableChild(buttonCalculate);
-        this.addDrawableChild(buttonStart);
-        this.addDrawableChild(buttonCancel);
+		this.addRenderableWidget(buttonSelect);
+		this.addRenderableWidget(buttonCalculate);
+		this.addRenderableWidget(buttonStart);
+		this.addRenderableWidget(buttonCancel);
 
-        Worker.setup(text, buttonSelect, buttonCalculate, buttonStart, buttonCancel);
-    }
+		Worker.setup(text, buttonSelect, buttonCalculate, buttonStart, buttonCancel);
+	}
 
-    @Inject(at = @At("RETURN"), method = "drawInvalidRecipeArrow")
-    private void drawInvalidRecipeArrow(DrawContext context, int xs, int ys, CallbackInfo info) {
-        boolean first = true;
-        for (int slot : Worker.getSelected()) {
-            int x = xs + handler.slots.get(slot).x;
-            int y = ys + handler.slots.get(slot).y;
-            context.fill(x, y, x + 16, y + 16, first ? Colors.BLUE : Colors.GREEN);
-            first = false;
-        }
+	@Inject(at = @At("RETURN"), method = "extractErrorIcon")
+	private void drawInvalidRecipeArrow(GuiGraphicsExtractor graphics, int xs, int ys, CallbackInfo info) {
+		boolean first = true;
+		for (int slot : Worker.getSelected()) {
+			int x = xs + menu.slots.get(slot).x;
+			int y = ys + menu.slots.get(slot).y;
+			graphics.fill(x, y, x + 16, y + 16, first ? Colors.BLUE : Colors.GREEN);
+			first = false;
+		}
 
-        double progress = Worker.getProgress();
-        if (progress >= 0) {
-            context.fill(20, 41, 120, 43, 0xFF909090);
-            context.fill(20, 41, (int) Math.round(progress * 100 + 20), 43, Colors.GREEN);
-        }
+		double progress = Worker.getProgress();
+		if (progress >= 0) {
+			graphics.fill(20, 41, 120, 43, 0xFF909090);
+			graphics.fill(20, 41, (int) Math.round(progress * 100 + 20), 43, Colors.GREEN);
+		}
 
-        DataStructures.Shape shape = Worker.getShape();
-        if (shape != null) {
-            shape.draw(context, textRenderer, 10, 105, 128, 128);
-        }
-    }
+		DataStructures.Shape shape = Worker.getShape();
+		if (shape != null) {
+			shape.draw(graphics, font, 10, 105, 128, 128);
+		}
+	}
 }

--- a/src/main/java/dev/gxlg/autoenchanter/mixin/ManagerMixin.java
+++ b/src/main/java/dev/gxlg/autoenchanter/mixin/ManagerMixin.java
@@ -1,45 +1,44 @@
 package dev.gxlg.autoenchanter.mixin;
 
 import dev.gxlg.autoenchanter.Worker;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ingame.AnvilScreen;
-import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Items;
-import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AnvilScreen;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@SuppressWarnings("UnresolvedMixinReference")
-@Mixin(ClientPlayerInteractionManager.class)
+@Mixin(MultiPlayerGameMode.class)
 public class ManagerMixin {
 
-    @Shadow
-    private MinecraftClient client;
+	@Shadow
+	private Minecraft minecraft;
 
-    @Inject(at = @At("HEAD"), method = "clickSlot", cancellable = true)
-    private void clickSlot(int syncId, int slotId, int button, SlotActionType actionType, PlayerEntity player, CallbackInfo info) {
-        if (Worker.getState() == Worker.State.SELECT) {
-            if (slotId > 2 && (
-                    Worker.getSelected().size() < 1 ||
-                    Worker.getSelected().contains(slotId) ||
-                    player.currentScreenHandler.getSlot(slotId).getStack().getItem() == Items.ENCHANTED_BOOK ||
-                    player.currentScreenHandler.getSlot(slotId).getStack().getItem() == player.currentScreenHandler.getSlot(Worker.getSelected().get(0)).getStack().getItem()
-            )) {
-                Worker.toggleSelection(slotId);
-            }
-            info.cancel();
-        }
-    }
+	@Inject(at = @At("HEAD"), method = "handleContainerInput", cancellable = true)
+	private void clickSlot(int syncId, int slotId, int button, ContainerInput actionType, Player player, CallbackInfo info) {
+		if (Worker.getState() == Worker.State.SELECT) {
+			if (slotId > 2 && (
+					Worker.getSelected().isEmpty() ||
+					Worker.getSelected().contains(slotId) ||
+					player.containerMenu.getSlot(slotId).getItem().getItem() == Items.ENCHANTED_BOOK ||
+					player.containerMenu.getSlot(slotId).getItem().getItem() == player.containerMenu.getSlot(Worker.getSelected().getFirst()).getItem().getItem()
+			)) {
+				Worker.toggleSelection(slotId);
+			}
+			info.cancel();
+		}
+	}
 
-    @Inject(at = @At("HEAD"), method = "tick")
-    private void tick(CallbackInfo info) {
-        if (client.currentScreen == null || !(client.currentScreen instanceof AnvilScreen)) {
-            Worker.closeScreen();
-        }
-        Worker.tick();
-    }
+	@Inject(at = @At("HEAD"), method = "tick")
+	private void tick(CallbackInfo info) {
+		if (!(minecraft.gui.screen() instanceof AnvilScreen)) {
+			Worker.closeScreen();
+		}
+		Worker.tick();
+	}
 }

--- a/src/main/resources/client.auto-enchanter.mixins.json
+++ b/src/main/resources/client.auto-enchanter.mixins.json
@@ -1,7 +1,7 @@
 {
 	"required": true,
 	"package": "dev.gxlg.autoenchanter.mixin",
-	"compatibilityLevel": "JAVA_21",
+	"compatibilityLevel": "JAVA_25",
 	"client": [
 		"AnvilMixin",
 		"ManagerMixin"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,9 +24,9 @@
 		"client.auto-enchanter.mixins.json"
 	],
 	"depends": {
-		"fabricloader": "*",
-		"minecraft": ">=1.20.5 <=1.21.11",
-		"java": ">=21",
+		"fabricloader": ">=0.19.3",
+		"minecraft": "~26.2",
+		"java": ">=25",
 		"fabric-api": "*"
 	}
 }


### PR DESCRIPTION
## Summary
- Upgrade the Fabric toolchain to Minecraft 26.2 (Loader 0.19.3, Loom 1.17, Fabric API 0.154.2+26.2, Gradle 9.5.1, Java 25).
- Migrate from Yarn to official Mojang mappings and update anvil UI/inventory click APIs for 26.2 (`GuiGraphicsExtractor`, `ContainerInput`, `gui.screen()`, etc.).
- Remove the MultiVersion reflection preprocessor from the build path in favor of direct Mojmap calls for this version.

## Test plan
- [x] `./gradlew build` succeeds against Minecraft 26.2
- [x] Install jar into a Fabric 26.2 Modrinth profile and launch without mixin/crash errors
- [x] Open anvil: Select / Calculate / Cancel / Start enchanting buttons appear and work
- [x] Select a sword first (blue), then enchanted books/sacrifices (green)
- [x] Calculate a full sword enchant set and confirm cost message / progress UI
- [x] Start enchanting and confirm auto slot moves complete the combine sequence
- [x] Re-check cancel mid-select / mid-calculate and `/autoenchanter cancel`
- [x] Re-check close-anvil-during-calculate and resume-after-close during enchanting
- [x] Re-check not-enough-levels pause/resume and incompatible enchant error handling
